### PR TITLE
Adds a configuration snippet for terminator.

### DIFF
--- a/Smyck.terminator
+++ b/Smyck.terminator
@@ -1,0 +1,6 @@
+# Copy the following lines into the [profiles] section:
+  [[Smyck]]
+    palette = "#000000:#c75646:#8eb33b:#d0b03c:#72b3cc:#c8a0d1:#218693:#b0b0b0:#5d5d5d:#e09690:#cdee69:#ffe377:#9cd9f0:#fbb1f9:#77dfd8:#f7f7f7"
+    cursor_color = "#c75646"
+    foreground_color = "#f7f7f7"
+    background_color = "#2d2d2d"


### PR DESCRIPTION
Installation: just copy the lines from Smyck.terminator into the
[profiles] section of the terminator config file (usually
'~/.config/terminator/config').